### PR TITLE
Add C++14 language

### DIFF
--- a/cms/grading/languages/cpp11_gpp.py
+++ b/cms/grading/languages/cpp11_gpp.py
@@ -16,7 +16,7 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-"""C++ programming language definition."""
+"""C++11 programming language definition."""
 
 from cms.grading import CompiledLanguage
 

--- a/cms/grading/languages/cpp14_gpp.py
+++ b/cms/grading/languages/cpp14_gpp.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+
+# Contest Management System - http://cms-dev.github.io/
+# Copyright © 2016 Stefano Maggiolo <s.maggiolo@gmail.com>
+# Copyright © 2019 Andrey Vihrov <andrey.vihrov@gmail.com>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""C++14 programming language definition."""
+
+from cms.grading import CompiledLanguage
+
+
+__all__ = ["Cpp14Gpp"]
+
+
+class Cpp14Gpp(CompiledLanguage):
+    """This defines the C++ programming language, compiled with g++ (the
+    version available on the system) using the C++14 standard.
+    """
+
+    @property
+    def name(self):
+        """See Language.name."""
+        return "C++14 / g++"
+
+    @property
+    def source_extensions(self):
+        """See Language.source_extensions."""
+        return [".cpp", ".cc", ".cxx", ".c++", ".C"]
+
+    @property
+    def header_extensions(self):
+        """See Language.source_extensions."""
+        return [".h"]
+
+    @property
+    def object_extensions(self):
+        """See Language.source_extensions."""
+        return [".o"]
+
+    def get_compilation_commands(self,
+                                 source_filenames, executable_filename,
+                                 for_evaluation=True):
+        """See Language.get_compilation_commands."""
+        command = ["/usr/bin/g++"]
+        if for_evaluation:
+            command += ["-DEVAL"]
+        command += ["-std=gnu++14", "-O2", "-pipe", "-static",
+                    "-s", "-o", executable_filename]
+        command += source_filenames
+        return [command]

--- a/setup.py
+++ b/setup.py
@@ -183,6 +183,7 @@ setup(
         ],
         "cms.grading.languages": [
             "C++11 / g++=cms.grading.languages.cpp11_gpp:Cpp11Gpp",
+            "C++14 / g++=cms.grading.languages.cpp14_gpp:Cpp14Gpp",
             "C11 / gcc=cms.grading.languages.c11_gcc:C11Gcc",
             "C# / Mono=cms.grading.languages.csharp_mono:CSharpMono",
             "Haskell / ghc=cms.grading.languages.haskell_ghc:HaskellGhc",


### PR DESCRIPTION
Add C++14 as a possible language for contests.  Setup is identical to C++11, except compiler uses the "-std=gnu++14" flag instead of "-std=gnu++11".